### PR TITLE
Add support for acl:origin in WAC documents

### DIFF
--- a/src/AclParser.ts
+++ b/src/AclParser.ts
@@ -19,6 +19,7 @@ const predicates = {
   agent: `${prefixes.acl}agent`,
   agentGroup: `${prefixes.acl}agentGroup`,
   agentClass: `${prefixes.acl}agentClass`,
+  origin: `${prefixes.acl}origin`,
   accessTo: `${prefixes.acl}accessTo`,
   default: `${prefixes.acl}default`,
   defaultForNew: `${prefixes.acl}defaultForNew`,
@@ -96,7 +97,7 @@ class AclParser {
 
   _isAclRule (quads: N3.Quad[]) {
     const requiredPredicates = [
-      [predicates.agent, predicates.agentClass, predicates.agentGroup],
+      [predicates.agent, predicates.agentClass, predicates.agentGroup, predicates.origin],
       [predicates.mode]
     ]
     return requiredPredicates.every(p => quads.some(({ predicate }) => p.includes(predicate.id)))
@@ -126,6 +127,10 @@ class AclParser {
 
       case predicates.agentGroup:
         rule.agents.addGroup(value)
+        break
+
+      case predicates.origin:
+        rule.agents.addOrigin(value)
         break
 
       case predicates.agentClass:
@@ -209,6 +214,13 @@ class AclParser {
         namedNode(subjectId),
         namedNode(predicates.agentGroup),
         namedNode(relative(group))
+      ))
+    }
+    for (const origin of rule.agents.origins) {
+      quads.push(quad(
+        namedNode(subjectId),
+        namedNode(predicates.origin),
+        namedNode(origin)
       ))
     }
     if (rule.agents.public) {

--- a/src/Agents.ts
+++ b/src/Agents.ts
@@ -31,12 +31,14 @@ export type AgentsCastable = Agents | string | string[] | undefined
 class Agents {
   public readonly webIds: Set<string>
   public readonly groups: Set<string>
+  public readonly origins: Set<string>
   public public: boolean
   public authenticated: boolean
 
   constructor (...webIds: string[]) {
     this.webIds = new Set()
     this.groups = new Set()
+    this.origins = new Set()
     this.public = false
     this.authenticated = false
 
@@ -68,6 +70,20 @@ class Agents {
 
   deleteGroup (...groups: string[]) {
     groups.forEach(group => this.groups.delete(group))
+    return this
+  }
+
+  addOrigin (...origins: string[]) {
+    origins.forEach(origin => this.origins.add(origin))
+    return this
+  }
+
+  hasOrigin (...origins: string[]) {
+    return origins.every(origin => this.origins.has(origin))
+  }
+
+  deleteOrigin (...origins: string[]) {
+    origins.forEach(origin => this.origins.delete(origin))
     return this
   }
 
@@ -110,6 +126,7 @@ class Agents {
 
     clone.addWebId(...this.webIds)
     clone.addGroup(...this.groups)
+    clone.addOrigin(...this.origins)
     clone.public = this.public
     clone.authenticated = this.authenticated
 
@@ -119,6 +136,7 @@ class Agents {
   equals (other: Agents) {
     return iterableEquals(this.webIds, other.webIds) &&
       iterableEquals(this.groups, other.groups) &&
+      iterableEquals(this.origins, other.origins) &&
       this.public === other.public &&
       this.authenticated === other.authenticated
   }
@@ -126,6 +144,7 @@ class Agents {
   includes (other: Agents) {
     return this.hasWebId(...other.webIds) &&
       this.hasGroup(...other.groups) &&
+      this.hasOrigin(...other.origins) &&
       (this.public || !other.public) &&
       (this.authenticated || !other.authenticated)
   }
@@ -133,6 +152,7 @@ class Agents {
   isEmpty () {
     return this.webIds.size === 0 &&
       this.groups.size === 0 &&
+      this.origins.size === 0 &&
       !this.public &&
       !this.authenticated
   }
@@ -162,6 +182,7 @@ class Agents {
     const agents = new Agents()
     agents.addWebId(...[...first.webIds].filter(webId => second.hasWebId(webId)))
     agents.addGroup(...[...first.groups].filter(group => second.hasGroup(group)))
+    agents.addOrigin(...[...first.origins].filter(origin => second.hasOrigin(origin)))
     if (first.hasPublic() && second.hasPublic()) {
       agents.addPublic()
     }
@@ -178,6 +199,7 @@ class Agents {
     const merged = first.clone()
     merged.addWebId(...second.webIds)
     merged.addGroup(...second.groups)
+    merged.addOrigin(...second.origins)
     merged.public = merged.public || second.public
     merged.authenticated = merged.authenticated || second.authenticated
 
@@ -191,6 +213,7 @@ class Agents {
     const agents = new Agents()
     agents.addWebId(...[...first.webIds].filter(webId => !second.hasWebId(webId)))
     agents.addGroup(...[...first.groups].filter(group => !second.hasGroup(group)))
+    agents.addOrigin(...[...first.origins].filter(origin => !second.hasOrigin(origin)))
     if (first.hasPublic() && !second.hasPublic()) {
       agents.addPublic()
     }

--- a/tests/Agents.test.js
+++ b/tests/Agents.test.js
@@ -11,8 +11,8 @@ const sampleGroups = [
   'https://bob.example.com/work-groups#Family'
 ]
 const sampleOrigins = [
-  'https://alice.example.com/',
-  'https://example.org/'
+  'https://alice.example.com',
+  'https://example.org'
 ]
 
 describe('create and manipulate agents', () => {
@@ -104,6 +104,7 @@ describe('create and manipulate agents', () => {
     first.addGroup(...sampleOrigins)
     const second = new Agents(...sampleWebIds.slice(1))
     second.addGroup(...sampleGroups)
+    second.addOrigin(...sampleOrigins)
     second.addPublic()
 
     const merged = Agents.merge(first, second)
@@ -224,12 +225,12 @@ describe('meta methods', () => {
       const first = new Agents()
       first.addWebId(...sampleWebIds)
       first.addGroup(...sampleGroups.slice(1))
-      first.addGroup(...sampleOrigins.slice(1))
+      first.addOrigin(...sampleOrigins.slice(1))
       first.addPublic()
       const second = new Agents()
       second.addWebId(sampleWebIds[0])
       second.addGroup(...sampleGroups)
-      second.addOrigins(...sampleOrigins)
+      second.addOrigin(...sampleOrigins)
       second.addPublic()
       second.addAuthenticated()
 

--- a/tests/Agents.test.js
+++ b/tests/Agents.test.js
@@ -10,6 +10,10 @@ const sampleGroups = [
   'https://alice.example.com/work-groups#Work',
   'https://bob.example.com/work-groups#Family'
 ]
+const sampleOrigins = [
+  'https://alice.example.com/',
+  'https://example.org/'
+]
 
 describe('create and manipulate agents', () => {
   test('can use constructor to add multiple webIds', () => {
@@ -29,6 +33,16 @@ describe('create and manipulate agents', () => {
 
     expect(agents.hasWebId(...sampleWebIds)).toBe(false)
     expect(agents.hasGroup(...sampleGroups)).toBe(false)
+  })
+  test('can add and remove all origins', () => {
+    const agents = new Agents()
+    agents.addOrigin(...sampleOrigins)
+
+    expect(agents.hasOrigin(...sampleOrigins)).toBe(true)
+
+    agents.deleteOrigin(...sampleOrigins)
+
+    expect(agents.hasOrigin(...sampleOrigins)).toBe(false)
   })
   test('can use public', () => {
     const agents = new Agents(...sampleWebIds)
@@ -51,10 +65,12 @@ describe('create and manipulate agents', () => {
     const agents = new Agents()
     agents.addWebId(...sampleWebIds)
       .addGroup(...sampleGroups)
+      .addOrigin(...sampleOrigins)
       .deletePublic()
       .deleteAuthenticated()
       .deleteWebId(sampleWebIds[0])
       .deleteGroup(sampleGroups[0])
+      .deleteOrigin(sampleOrigins[0])
       .addPublic()
       .addAuthenticated()
 
@@ -62,6 +78,8 @@ describe('create and manipulate agents', () => {
     expect(agents.hasWebId(...sampleWebIds.slice(1))).toBe(true)
     expect(agents.hasGroup(sampleGroups[0])).toBe(false)
     expect(agents.hasGroup(...sampleGroups.slice(1))).toBe(true)
+    expect(agents.hasOrigin(sampleOrigins[0])).toBe(false)
+    expect(agents.hasOrigin(...sampleOrigins.slice(1))).toBe(true)
     expect(agents.hasPublic()).toBe(true)
     expect(agents.hasAuthenticated()).toBe(true)
   })
@@ -83,6 +101,7 @@ describe('create and manipulate agents', () => {
   test('can use merge to get all agents from both instances', () => {
     const first = new Agents(sampleWebIds[0])
     first.addGroup(...sampleGroups)
+    first.addGroup(...sampleOrigins)
     const second = new Agents(...sampleWebIds.slice(1))
     second.addGroup(...sampleGroups)
     second.addPublic()
@@ -91,6 +110,7 @@ describe('create and manipulate agents', () => {
 
     expect(merged.hasWebId(...sampleWebIds)).toBe(true)
     expect(merged.hasGroup(...sampleGroups)).toBe(true)
+    expect(merged.hasOrigin(...sampleOrigins)).toBe(true)
     expect(merged.hasPublic()).toBe(true)
     expect(merged.hasAuthenticated()).toBe(false)
   })
@@ -164,6 +184,9 @@ describe('meta methods', () => {
       agents.addGroup(sampleGroups[0])
       expect(agents.isEmpty()).toBe(false)
       agents = new Agents()
+      agents.addOrigin(sampleOrigins[0])
+      expect(agents.isEmpty()).toBe(false)
+      agents = new Agents()
       agents.addPublic()
       expect(agents.isEmpty()).toBe(false)
       agents = new Agents()
@@ -201,10 +224,12 @@ describe('meta methods', () => {
       const first = new Agents()
       first.addWebId(...sampleWebIds)
       first.addGroup(...sampleGroups.slice(1))
+      first.addGroup(...sampleOrigins.slice(1))
       first.addPublic()
       const second = new Agents()
       second.addWebId(sampleWebIds[0])
       second.addGroup(...sampleGroups)
+      second.addOrigins(...sampleOrigins)
       second.addPublic()
       second.addAuthenticated()
 
@@ -213,6 +238,8 @@ describe('meta methods', () => {
       expect(common.hasWebId(...sampleWebIds.slice(1))).toBe(false)
       expect(common.hasGroup(sampleGroups[0])).toBe(false)
       expect(common.hasGroup(...sampleGroups.slice(1))).toBe(true)
+      expect(common.hasOrigin(sampleOrigins[0])).toBe(false)
+      expect(common.hasOrigin(...sampleOrigins.slice(1))).toBe(true)
       expect(common.hasPublic()).toBe(true)
       expect(common.hasAuthenticated()).toBe(false)
     })
@@ -248,5 +275,10 @@ describe('meta methods', () => {
     const agents = new Agents()
     agents.addGroup(...sampleGroups)
     expect(agents.groups).toEqual(expect.any(Set))
+  })
+  test('agents.origins is of the type Set', () => {
+    const agents = new Agents()
+    agents.addOrigin(...sampleOrigins)
+    expect(agents.origins).toEqual(expect.any(Set))
   })
 })


### PR DESCRIPTION
The usage should be the same as acl groups (addOrigin, hasOrigin etc all should work).